### PR TITLE
20250709 convmp4 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Qiita用のネタで作った痒い所に手が届いて欲しいバッチコマ
 
 Name                           Value
 ----                           -----
-PSVersion                      7.4.4
+PSVersion                      7.5.2
 PSEdition                      Core
-GitCommitId                    7.4.4
+GitCommitId                    7.5.2
 OS                             Microsoft Windows 10.0.19045
 Platform                       Win32NT
 PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
@@ -22,33 +22,31 @@ PSRemotingProtocolVersion      2.3
 SerializationVersion           1.1.0.1
 WSManStackVersion              3.0
 
+
 > ffmpeg -version
-ffmpeg version 4.3.1-2020-11-19-full_build-www.gyan.dev Copyright (c) 2000-2020 the FFmpeg developers
-built with gcc 10.2.0 (Rev5, Built by MSYS2 project)
-configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-libxml2 --enable-gmp --enable-lzma --enable-libsnappy --enable-zlib --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-sdl2 --enable-libdav1d --enable-libzvbi --enable-librav1e --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxvid --enable-libaom --enable-libopenjpeg --enable-libvpx --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-ffnvcodec --enable-nvdec --enable-nvenc --enable-d3d11va --enable-dxva2 --enable-libmfx --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libilbc --enable-libgsm --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
-libavutil      56. 51.100 / 56. 51.100
-libavcodec     58. 91.100 / 58. 91.100
-libavformat    58. 45.100 / 58. 45.100
-libavdevice    58. 10.100 / 58. 10.100
-libavfilter     7. 85.100 /  7. 85.100
-libswscale      5.  7.100 /  5.  7.100
-libswresample   3.  7.100 /  3.  7.100
-libpostproc    55.  7.100 / 55.  7.100
+ffmpeg version 7.1.1-full_build-www.gyan.dev Copyright (c) 2000-2025 the FFmpeg developers
+built with gcc 14.2.0 (Rev1, Built by MSYS2 project)
+configuration: --enable-gpl --enable-version3 --enable-static --disable-w32threads --disable-autodetect --enable-fontconfig --enable-iconv --enable-gnutls --enable-lcms2 --enable-libxml2 --enable-gmp --enable-bzlib --enable-lzma --enable-libsnappy --enable-zlib --enable-librist --enable-libsrt --enable-libssh --enable-libzmq --enable-avisynth --enable-libbluray --enable-libcaca --enable-libdvdnav --enable-libdvdread --enable-sdl2 --enable-libaribb24 --enable-libaribcaption --enable-libdav1d --enable-libdavs2 --enable-libopenjpeg --enable-libquirc --enable-libuavs3d --enable-libxevd --enable-libzvbi --enable-libqrencode --enable-librav1e --enable-libsvtav1 --enable-libvvenc --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxeve --enable-libxvid --enable-libaom --enable-libjxl --enable-libvpx --enable-mediafoundation --enable-libass --enable-frei0r --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-liblensfun --enable-libvidstab --enable-libvmaf --enable-libzimg --enable-amf --enable-cuda-llvm --enable-cuvid --enable-dxva2 --enable-d3d11va --enable-d3d12va --enable-ffnvcodec --enable-libvpl --enable-nvdec --enable-nvenc --enable-vaapi --enable-libshaderc --enable-vulkan --enable-libplacebo --enable-opencl --enable-libcdio --enable-libgme --enable-libmodplug --enable-libopenmpt --enable-libopencore-amrwb --enable-libmp3lame --enable-libshine --enable-libtheora --enable-libtwolame --enable-libvo-amrwbenc --enable-libcodec2 --enable-libilbc --enable-libgsm --enable-liblc3 --enable-libopencore-amrnb --enable-libopus --enable-libspeex --enable-libvorbis --enable-ladspa --enable-libbs2b --enable-libflite --enable-libmysofa --enable-librubberband --enable-libsoxr --enable-chromaprint
+libavutil      59. 39.100 / 59. 39.100
+libavcodec     61. 19.101 / 61. 19.101
+libavformat    61.  7.100 / 61.  7.100
+libavdevice    61.  3.100 / 61.  3.100
+libavfilter    10.  4.100 / 10.  4.100
+libswscale      8.  3.100 /  8.  3.100
+libswresample   5.  3.100 /  5.  3.100
+libpostproc    58.  3.100 / 58.  3.100
 ```
 
 
 # インストール
 1. zipでダウンロードします。
 2. ダウンロードしたzipを任意のフォルダに展開します。
-3. 展開したフォルダ（`(zip)\alstroemeria\bat`）にwindowsのパスを通して下さい。
-    - 以前使ってた人は、フォルダが `bin` から `bat` に変わっていますのでご注意を！ 
-5. いくつかのコマンドはffmpegを使用します。別途ダウンロードをして、ffmpegもwindowsのパスを通した状態にして下さい。
-6. いくつかのコマンドは7zを使用します。別途ダウンロードをして、7zもwindowsのパスを通した状態にして下さい。
-7. コマンドプロンプトで `ahelp` と入れて応答が返ってくればOKです。
+3. 展開したフォルダ（`(zip)\alstroemeria\bat` や `(zip)\alstroemeria\ps1` 等）にwindowsのパスを適宜通して下さい。
+4. いくつかのコマンドはffmpegを使用します。別途ダウンロードをして、ffmpegもwindowsのパスを通した状態にして下さい。
+5. いくつかのコマンドは7zを使用します。別途ダウンロードをして、7zもwindowsのパスを通した状態にして下さい。
 
 
 # 使い方
-- 困ったら`ahelp`でコマンド一覧をみて下さい。
 - 各コマンドの実装ポリシーとして、オプション無しの起動はヘルプを表示するようにしています。気になるコマンドをオプション無しでバシバシ叩いてください。
 
 
@@ -57,14 +55,14 @@ libpostproc    55.  7.100 / 55.  7.100
 2. 本コマンド群を展開したフォルダを削除します。
 
 
-
 # ps1フォルダについて
-PowerShellのツールが入っています。
-どのスクリプトも引数無しで起動するとヘルプが見られるので、確認して下さい。
+PowerShellのツールが入っています。  
+どのスクリプトも引数無しで起動するとヘルプが見られるので、確認して下さい。  
 もしくはソースを直接覗いて下さい。
 
 ## convert-to-lite-mp4.ps1
-指定したフォルダに入っている動画ファイルを、程々の品質に落として軽量化するスクリプトです。
+指定したフォルダに入っている動画ファイルを、程々の品質に落として軽量化するスクリプトです。  
+※2025/07時点で使用している私のグラボ（RTX 2070 SUPER）でAV1の処理が出来ない為、CPU処理に切り替えるようにしてます。
 
 ## check-appdata.ps1
 任意のユーザのAppDataの中から、容量をバカ食いしているフォルダを探します。

--- a/ps1/dtos/FfprobeDto.ps1
+++ b/ps1/dtos/FfprobeDto.ps1
@@ -21,7 +21,7 @@ class FfprobeDto {
         $ffprobeParams = @(
             "-v", "error",
             "-show_streams",
-            "-show_entries", "stream=width,height,color_space,color_range,bit_rate,channels,sample_rate,handler_name",
+            "-show_entries", "stream=width,height,color_space,color_range,bit_rate,sample_rate,codec_type,disposition,codec_name",
             "-of", "json",
             """$($this.mediaFilePath)"""
         )
@@ -47,27 +47,18 @@ class FfprobeDto {
         Remove-Item -Path $procArgs.RedirectStandardOutput, $procArgs.RedirectStandardError -ErrorAction SilentlyContinue
 
         $jsonReplay = $replay | ConvertFrom-Json
+        
+        # ビデオストリームの候補を収集
+        $videoStreams = @()
+        $audioStreams = @()
+        
         foreach ($stream in $jsonReplay.streams) {
-            $handler = if ($stream.tags -and $stream.tags.PSObject.Properties.Name -contains "handler_name") {
-                $stream.tags.handler_name.Trim()
+            if ($stream.codec_type -eq "video") {
+                $videoStreams += $stream
+            } elseif ($stream.codec_type -eq "audio") {
+                $audioStreams += $stream
             } else {
-                ""
-            }
-
-            if ($handler -match "(?i)Video") {  # (?i) で大文字小文字無視
-                $this.Video = [VideoInfo]::new()
-                $this.Video.Width = if ($stream.width -match '^\d+$') { [int]$stream.width } else { $null }
-                $this.Video.Height = if ($stream.height -match '^\d+$') { [int]$stream.height } else { $null }
-                $this.Video.ColorSpace = $stream.color_space
-                $this.Video.ColorRange = $stream.color_range
-                $this.Video.BitRate = if ($stream.bit_rate -eq "N/A" -or -not ($stream.bit_rate -match '^\d+$')) { -1 } else { [int]$stream.bit_rate }
-            } elseif ($handler -match "(?i)(Audio|Sound)") {  # Audio か Sound を検出
-                $this.Audio = [AudioInfo]::new()
-                $this.Audio.BitRate = if ($stream.bit_rate -eq "N/A" -or -not ($stream.bit_rate -match '^\d+$')) { -1 } else { [int]$stream.bit_rate }
-                $this.Audio.Channels = if ($stream.channels -eq "N/A" -or -not ($stream.channels -match '^\d+$')) { -1 } else { [int]$stream.channels }
-                $this.Audio.SampleRate = if ($stream.sample_rate -eq "N/A" -or -not ($stream.sample_rate -match '^\d+$')) { -1 } else { [int]$stream.sample_rate }
-                $this.Audio.MaxVolume = if ($errReplay -match "max_volume: ([-\d.]+)") { [double]$matches[1] } else { 0 }
-            } else {
+                # メタ情報処理（従来通り）
                 if (-not $this.Meta -and $stream.width) {
                     $this.Meta = [MetaInfo]::new()
                     $this.Meta.Width = if ($stream.width -match '^\d+$') { [int]$stream.width } else { $null }
@@ -77,6 +68,145 @@ class FfprobeDto {
                 }
             }
         }
+
+        # 最も高品質なビデオストリームを選択
+        if ($videoStreams.Count -gt 0) {
+            $bestVideoStream = $this.SelectBestVideoStream($videoStreams)
+            
+            $this.Video = [VideoInfo]::new()
+            $this.Video.Width = if ($bestVideoStream.width -match '^\d+$') { [int]$bestVideoStream.width } else { $null }
+            $this.Video.Height = if ($bestVideoStream.height -match '^\d+$') { [int]$bestVideoStream.height } else { $null }
+            $this.Video.ColorSpace = $bestVideoStream.color_space
+            $this.Video.ColorRange = $bestVideoStream.color_range
+            $this.Video.BitRate = if ($bestVideoStream.bit_rate -eq "N/A" -or -not ($bestVideoStream.bit_rate -match '^\d+$')) { -1 } else { [int]$bestVideoStream.bit_rate }
+            $this.Video.Codec = $bestVideoStream.codec_name
+        }
+
+        # 最も高品質なオーディオストリームを選択
+        if ($audioStreams.Count -gt 0) {
+            $bestAudioStream = $this.SelectBestAudioStream($audioStreams)
+            
+            $this.Audio = [AudioInfo]::new()
+            $this.Audio.BitRate = if ($bestAudioStream.bit_rate -eq "N/A" -or -not ($bestAudioStream.bit_rate -match '^\d+$')) { -1 } else { [int]$bestAudioStream.bit_rate }
+            $this.Audio.SampleRate = if ($bestAudioStream.sample_rate -eq "N/A" -or -not ($bestAudioStream.sample_rate -match '^\d+$')) { -1 } else { [int]$bestAudioStream.sample_rate }
+            $this.Audio.MaxVolume = if ($errReplay -match "max_volume: ([-\d.]+)") { [double]$matches[1] } else { 0 }
+        }
+    }
+
+    <#
+    最も高品質なビデオストリームを選択する
+    優先順位：
+    1. attached_pic (サムネイル) を除外
+    2. 解像度（幅×高さ）が最も高い
+    3. ビットレートが最も高い
+    4. defaultストリーム
+    #>
+    hidden [object] SelectBestVideoStream([array]$videoStreams) {
+        # attached_pic（サムネイル）を除外
+        $mainVideoStreams = $videoStreams | Where-Object { 
+            -not ($_.disposition -and $_.disposition.attached_pic -eq 1)
+        }
+        
+        # メインビデオストリームがない場合は全てから選択
+        if ($mainVideoStreams.Count -eq 0) {
+            $mainVideoStreams = $videoStreams
+        }
+        
+        # 1つしかない場合はそれを返す
+        if ($mainVideoStreams.Count -eq 1) {
+            return $mainVideoStreams[0]
+        }
+        
+        # 複数ある場合は品質で選択
+        $bestStream = $mainVideoStreams[0]
+        
+        foreach ($stream in $mainVideoStreams) {
+            # 解像度で比較（幅×高さ）
+            $currentResolution = if ($stream.width -match '^\d+$' -and $stream.height -match '^\d+$') {
+                [int]$stream.width * [int]$stream.height
+            } else { 0 }
+            
+            $bestResolution = if ($bestStream.width -match '^\d+$' -and $bestStream.height -match '^\d+$') {
+                [int]$bestStream.width * [int]$bestStream.height
+            } else { 0 }
+            
+            if ($currentResolution -gt $bestResolution) {
+                $bestStream = $stream
+                continue
+            }
+            
+            # 解像度が同じ場合はビットレートで比較
+            if ($currentResolution -eq $bestResolution) {
+                $currentBitrate = if ($stream.bit_rate -match '^\d+$') { [int]$stream.bit_rate } else { 0 }
+                $bestBitrate = if ($bestStream.bit_rate -match '^\d+$') { [int]$bestStream.bit_rate } else { 0 }
+                
+                if ($currentBitrate -gt $bestBitrate) {
+                    $bestStream = $stream
+                    continue
+                }
+                
+                # ビットレートも同じ場合はdefaultストリームを優先
+                if ($currentBitrate -eq $bestBitrate) {
+                    if ($stream.disposition -and $stream.disposition.default -eq 1) {
+                        $bestStream = $stream
+                    }
+                }
+            }
+        }
+        
+        return $bestStream
+    }
+
+    <#
+    最も高品質なオーディオストリームを選択する
+    優先順位：
+    1. サンプリングレートが最も高い
+    2. ビットレートが最も高い
+    3. defaultストリーム
+    #>
+    hidden [object] SelectBestAudioStream([array]$audioStreams) {
+        # 1つしかない場合はそれを返す
+        if ($audioStreams.Count -eq 1) {
+            return $audioStreams[0]
+        }
+        
+        # 複数ある場合は品質で選択
+        $bestStream = $audioStreams[0]
+        
+        foreach ($stream in $audioStreams) {
+            # サンプリングレートで比較
+            $currentSampleRate = if ($stream.sample_rate -match '^\d+$') { [int]$stream.sample_rate } else { 0 }
+            $bestSampleRate = if ($bestStream.sample_rate -match '^\d+$') { [int]$bestStream.sample_rate } else { 0 }
+            
+            if ($currentSampleRate -gt $bestSampleRate) {
+                $bestStream = $stream
+                continue
+            }
+            
+            # サンプリングレートが同じ場合はビットレートで比較
+            if ($currentSampleRate -eq $bestSampleRate) {
+                $currentBitrate = if ($stream.bit_rate -match '^\d+$') { [int]$stream.bit_rate } else { 0 }
+                $bestBitrate = if ($bestStream.bit_rate -match '^\d+$') { [int]$bestStream.bit_rate } else { 0 }
+                
+                if ($currentBitrate -gt $bestBitrate) {
+                    $bestStream = $stream
+                    continue
+                }
+                
+                # ビットレートも同じ場合はdefaultストリームを優先
+                if ($currentBitrate -eq $bestBitrate) {
+                    if ($stream.disposition -and $stream.disposition.default -eq 1) {
+                        $bestStream = $stream
+                    }
+                }
+            }
+        }
+        
+        return $bestStream
+    }
+
+    [bool] IsAV1() {
+        return $this.Video -and $this.Video.Codec -eq "av1"
     }
 
     [string] ToString() {
@@ -90,11 +220,11 @@ class VideoInfo {
     [string]$ColorSpace
     [string]$ColorRange
     [int]$BitRate
+    [string]$Codec
 }
 
 class AudioInfo {
     [int]$BitRate
-    [int]$Channels
     [int]$SampleRate
     [double]$MaxVolume
 }


### PR DESCRIPTION
## 変更点
- AV1の処理が出来ない為、CPU処理に切り替えた
    - ffprobeコマンドの解析を外だしした
- Googleエンコーダを使った動画のhandler_nameからストリーム情報が動画か音声かを判断できないので、Codec名を使った解析をするように変更した